### PR TITLE
Add support for IFC files

### DIFF
--- a/lib/Model/ManifestChildren.php
+++ b/lib/Model/ManifestChildren.php
@@ -161,6 +161,7 @@ class ManifestChildren implements ArrayAccess
     const TYPE_VIEW = 'view';
     const ROLE__2D = '2d';
     const ROLE__3D = '3d';
+    const ROLE__IFC = 'ifc';
     const ROLE_GRAPHICS = 'graphics';
     const ROLE_MANIFEST = 'manifest';
     const ROLE_THUMBNAIL = 'thumbnail';
@@ -196,6 +197,7 @@ class ManifestChildren implements ArrayAccess
         return [
             self::ROLE__2D,
             self::ROLE__3D,
+            self::ROLE__IFC,
             self::ROLE_GRAPHICS,
             self::ROLE_MANIFEST,
             self::ROLE_THUMBNAIL,
@@ -266,9 +268,9 @@ class ManifestChildren implements ArrayAccess
         if ($this->container['role'] === null) {
             $invalid_properties[] = "'role' can't be null";
         }
-        $allowed_values = ["2d", "3d", "graphics", "manifest", "thumbnail"];
+        $allowed_values = ["2d", "3d", "graphics", "manifest", "thumbnail", "ifc"];
         if (!in_array($this->container['role'], $allowed_values)) {
-            $invalid_properties[] = "invalid value for 'role', must be one of '2d', '3d', 'graphics', 'manifest', 'thumbnail'.";
+            $invalid_properties[] = "invalid value for 'role', must be one of '2d', '3d', 'graphics', 'manifest', 'thumbnail', 'ifc'.";
         }
 
         if ($this->container['mime'] === null) {
@@ -358,9 +360,9 @@ class ManifestChildren implements ArrayAccess
      */
     public function setRole($role)
     {
-        $allowed_values = array('2d', '3d', 'graphics', 'manifest', 'thumbnail','Autodesk.CloudPlatform.PropertyDatabase','viewable');
+        $allowed_values = array('2d', '3d', 'graphics', 'manifest', 'thumbnail','Autodesk.CloudPlatform.PropertyDatabase','viewable', 'ifc');
         if ((!in_array($role, $allowed_values))) {
-            throw new \InvalidArgumentException("Invalid value for 'role', must be one of '2d', '3d', 'graphics', 'manifest', 'thumbnail','Autodesk.CloudPlatform.PropertyDatabase','viewable'");
+            throw new \InvalidArgumentException("Invalid value for 'role', must be one of '2d', '3d', 'graphics', 'manifest', 'thumbnail','Autodesk.CloudPlatform.PropertyDatabase','viewable', 'ifc'");
         }
         $this->container['role'] = $role;
 

--- a/lib/Model/ManifestDerivative.php
+++ b/lib/Model/ManifestDerivative.php
@@ -132,6 +132,7 @@ class ManifestDerivative implements ArrayAccess
     const OUTPUT_TYPE_IGES = 'iges';
     const OUTPUT_TYPE_OBJ = 'obj';
     const OUTPUT_TYPE_SVF = 'svf';
+    const OUTPUT_TYPE_IFC = 'ifc';
     const OUTPUT_TYPE_THUMBNAIL = 'thumbnail';
     const STATUS_PENDING = 'pending';
     const STATUS_INPROGRESS = 'inprogress';
@@ -154,6 +155,7 @@ class ManifestDerivative implements ArrayAccess
             self::OUTPUT_TYPE_IGES,
             self::OUTPUT_TYPE_OBJ,
             self::OUTPUT_TYPE_SVF,
+            self::OUTPUT_TYPE_IFC,
             self::OUTPUT_TYPE_THUMBNAIL,
         ];
     }
@@ -210,9 +212,9 @@ class ManifestDerivative implements ArrayAccess
         if ($this->container['has_thumbnail'] === null) {
             $invalid_properties[] = "'has_thumbnail' can't be null";
         }
-        $allowed_values = ["stl", "step", "iges", "obj", "svf", "thumbnail"];
+        $allowed_values = ["stl", "step", "iges", "obj", "svf", "thumbnail", "ifc"];
         if (!in_array($this->container['output_type'], $allowed_values)) {
-            $invalid_properties[] = "invalid value for 'output_type', must be one of 'stl', 'step', 'iges', 'obj', 'svf', 'thumbnail'.";
+            $invalid_properties[] = "invalid value for 'output_type', must be one of 'stl', 'step', 'iges', 'obj', 'svf', 'thumbnail', 'ifc'.";
         }
 
         if ($this->container['progress'] === null) {
@@ -247,7 +249,7 @@ class ManifestDerivative implements ArrayAccess
         if ($this->container['has_thumbnail'] === null) {
             return false;
         }
-        $allowed_values = ["stl", "step", "iges", "obj", "svf", "thumbnail"];
+        $allowed_values = ["stl", "step", "iges", "obj", "svf", "thumbnail", "ifc"];
         if (!in_array($this->container['output_type'], $allowed_values)) {
             return false;
         }
@@ -326,9 +328,9 @@ class ManifestDerivative implements ArrayAccess
      */
     public function setOutputType($output_type)
     {
-        $allowed_values = array('stl', 'step', 'iges', 'obj', 'svf', 'thumbnail');
+        $allowed_values = array('stl', 'step', 'iges', 'obj', 'svf', 'thumbnail', 'ifc');
         if (!is_null($output_type) && (!in_array($output_type, $allowed_values))) {
-            throw new \InvalidArgumentException("Invalid value for 'output_type', must be one of 'stl', 'step', 'iges', 'obj', 'svf', 'thumbnail'");
+            throw new \InvalidArgumentException("Invalid value for 'output_type', must be one of 'stl', 'step', 'iges', 'obj', 'svf', 'thumbnail', 'ifc'");
         }
         $this->container['output_type'] = $output_type;
 


### PR DESCRIPTION
Currently when you have a derivative which is converted from source model to .ifc the API client throws exceptions. This PR adds support for IFC derivatives in the API client.