### PR TITLE
Enhancement for uploading large files

### DIFF
--- a/docs/Api/ObjectsApi.md
+++ b/docs/Api/ObjectsApi.md
@@ -490,14 +490,18 @@ $object_name = "object_name_example"; // string | URL-encoded object name
 $content_length = 56; // int | Indicates the size of the request body.
 $content_range = "content_range_example"; // string | Byte range of a segment being uploaded
 $session_id = "session_id_example"; // string | Unique identifier of a session of a file being uploaded
-$body = "file contents or resource handle"; // either string | File contents or resource | File stream
+$body = "file contents"; // File contents
+$fileHandle = fopen('/path/to/file', 'r+'); // File resource handle
 $content_disposition = "content_disposition_example"; // string | The suggested default filename when downloading this object to a file after it has been uploaded.
 $if_match = "if_match_example"; // string | If-Match header containing a SHA-1 hash of the bytes in the request body can be sent by the calling service or client application with the request. If present, OSS will use the value of If-Match header to verify that a SHA-1 calculated for the uploaded bytes server side matches what was sent in the header. If not, the request is failed with a status 412 Precondition Failed and the data is not written.
 
 try {
-    $fileHandle = fopen('/path/to/file', 'r+');
-    $result = $apiInstance->uploadChunk($bucket_key, $object_name, $content_length, $content_range, $session_id, $fileHandle, $content_disposition, $if_match);
-    print_r($result);
+    //Upload file contents
+    $resultUploadContent = $apiInstance->uploadSignedResourcesChunk($id, $content_range, $session_id, $body, $content_disposition, $x_ads_region);
+    print_r($resultUploadContent);
+    //Upload file as stream
+    $resultUploadFile = $apiInstance->uploadSignedResourcesChunk($id, $content_range, $session_id, $fileHandle, $content_disposition, $x_ads_region);
+    print_r($resultUploadFile);
 } catch (Exception $e) {
     echo 'Exception when calling ObjectsApi->uploadChunk: ', $e->getMessage(), PHP_EOL;
 }
@@ -513,7 +517,7 @@ Name | Type | Description  | Notes
  **content_length** | **int**| Indicates the size of the request body. |
  **content_range** | **string**| Byte range of a segment being uploaded |
  **session_id** | **string**| Unique identifier of a session of a file being uploaded |
- **body** | **string or resource**| File contents or its resource handle |
+ **body | fileHandle** | **string or resource**| File contents or its resource handle |
  **content_disposition** | **string**| The suggested default filename when downloading this object to a file after it has been uploaded. | [optional]
  **if_match** | **string**| If-Match header containing a SHA-1 hash of the bytes in the request body can be sent by the calling service or client application with the request. If present, OSS will use the value of If-Match header to verify that a SHA-1 calculated for the uploaded bytes server side matches what was sent in the header. If not, the request is failed with a status 412 Precondition Failed and the data is not written. | [optional]
 
@@ -548,14 +552,18 @@ $apiInstance = new Autodesk\Forge\Client\Api\ObjectsApi($authObject);
 $bucket_key = "bucket_key_example"; // string | URL-encoded bucket key
 $object_name = "object_name_example"; // string | URL-encoded object name
 $content_length = 56; // int | Indicates the size of the request body.
-$body = "file contents or resource handle"; // either string or File contents or resource handle
+$body = "file contents"; // File contents
+$fileHandle = fopen('/path/to/file', 'r+'); // File resource handle
 $content_disposition = "content_disposition_example"; // string | The suggested default filename when downloading this object to a file after it has been uploaded.
 $if_match = "if_match_example"; // string | If-Match header containing a SHA-1 hash of the bytes in the request body can be sent by the calling service or client application with the request. If present, OSS will use the value of If-Match header to verify that a SHA-1 calculated for the uploaded bytes server side matches what was sent in the header. If not, the request is failed with a status 412 Precondition Failed and the data is not written.
 
 try {
-    $fileHandle = fopen('/path/to/file', 'r+');
-    $result = $apiInstance->uploadObject($bucket_key, $object_name, $content_length, $fileHandle, $content_disposition, $if_match);
-    print_r($result);
+     //Upload file contents
+    $resultUploadContent = $apiInstance->uploadSignedResourcesChunk($id, $content_range, $session_id, $body, $content_disposition, $x_ads_region);
+    print_r($resultUploadContent);
+    //Upload file as stream
+    $resultUploadFile = $apiInstance->uploadSignedResourcesChunk($id, $content_range, $session_id, $fileHandle, $content_disposition, $x_ads_region);
+    print_r($resultUploadFile);
 } catch (Exception $e) {
     echo 'Exception when calling ObjectsApi->uploadObject: ', $e->getMessage(), PHP_EOL;
 }
@@ -569,7 +577,7 @@ Name | Type | Description  | Notes
  **bucket_key** | **string**| URL-encoded bucket key |
  **object_name** | **string**| URL-encoded object name |
  **content_length** | **int**| Indicates the size of the request body. |
- **body** | **string or resource**| File contents or its resource handle |
+ **body | fileHandle** | **string or resource**| File contents or its resource handle |
  **content_disposition** | **string**| The suggested default filename when downloading this object to a file after it has been uploaded. | [optional]
  **if_match** | **string**| If-Match header containing a SHA-1 hash of the bytes in the request body can be sent by the calling service or client application with the request. If present, OSS will use the value of If-Match header to verify that a SHA-1 calculated for the uploaded bytes server side matches what was sent in the header. If not, the request is failed with a status 412 Precondition Failed and the data is not written. | [optional]
 
@@ -603,15 +611,19 @@ require_once(__DIR__ . '/vendor/autoload.php');
 $apiInstance = new Autodesk\Forge\Client\Api\ObjectsApi($authObject);
 $id = "id_example"; // string | Id of signed resource
 $content_length = 56; // int | Indicates the size of the request body.
-$body = "file contents or resource handle"; // either string or File contents or resource handle
+$body = "file contents"; // File contents
+$fileHandle = fopen('/path/to/file', 'r+'); // File resource handle
 $content_disposition = "content_disposition_example"; // string | The suggested default filename when downloading this object to a file after it has been uploaded.
 $x_ads_region = "US"; // string | The region where the bucket resides Acceptable values: `US`, `EMEA` Default is `US`
 $if_match = "if_match_example"; // string | If-Match header containing a SHA-1 hash of the bytes in the request body can be sent by the calling service or client application with the request. If present, OSS will use the value of If-Match header to verify that a SHA-1 calculated for the uploaded bytes server side matches what was sent in the header. If not, the request is failed with a status 412 Precondition Failed and the data is not written.
 
 try {
-    $fileHandle = fopen('/path/to/file', 'r+');
-    $result = $apiInstance->uploadSignedResource($id, $content_length, $fileHandle, $content_disposition, $x_ads_region, $if_match);
-    print_r($result);
+    //Upload file contents
+    $resultUploadContent = $apiInstance->uploadSignedResourcesChunk($id, $content_range, $session_id, $body, $content_disposition, $x_ads_region);
+    print_r($resultUploadContent);
+    //Upload file as stream
+    $resultUploadFile = $apiInstance->uploadSignedResourcesChunk($id, $content_range, $session_id, $fileHandle, $content_disposition, $x_ads_region);
+    print_r($resultUploadFile);
 } catch (Exception $e) {
     echo 'Exception when calling ObjectsApi->uploadSignedResource: ', $e->getMessage(), PHP_EOL;
 }
@@ -624,7 +636,7 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **id** | **string**| Id of signed resource |
  **content_length** | **int**| Indicates the size of the request body. |
- **body** | **string or resource**| File contents or its resource handle |
+ **body | fileHandle** | **string or resource**| File contents or its resource handle |
  **content_disposition** | **string**| The suggested default filename when downloading this object to a file after it has been uploaded. | [optional]
  **x_ads_region** | **string**| The region where the bucket resides Acceptable values: &#x60;US&#x60;, &#x60;EMEA&#x60; Default is &#x60;US&#x60; | [optional] [default to US]
  **if_match** | **string**| If-Match header containing a SHA-1 hash of the bytes in the request body can be sent by the calling service or client application with the request. If present, OSS will use the value of If-Match header to verify that a SHA-1 calculated for the uploaded bytes server side matches what was sent in the header. If not, the request is failed with a status 412 Precondition Failed and the data is not written. | [optional]
@@ -660,14 +672,19 @@ $apiInstance = new Autodesk\Forge\Client\Api\ObjectsApi($authObject);
 $id = "id_example"; // string | Id of signed resource
 $content_range = "content_range_example"; // string | Byte range of a segment being uploaded
 $session_id = "session_id_example"; // string | Unique identifier of a session of a file being uploaded
-$body = "file contents or resource handle"; // either string or File contents or resource handle
+$body = "file contents"; // File contents
+$fileHandle = fopen('/path/to/file', 'r+'); // File resource handle
 $content_disposition = "content_disposition_example"; // string | The suggested default filename when downloading this object to a file after it has been uploaded.
 $x_ads_region = "US"; // string | The region where the bucket resides Acceptable values: `US`, `EMEA` Default is `US`
 
 try {
-    $fileHandle = fopen('/path/to/file', 'r+');
-    $result = $apiInstance->uploadSignedResourcesChunk($id, $content_range, $session_id, $fileHandle, $content_disposition, $x_ads_region);
-    print_r($result);
+    //Upload file contents
+    $resultUploadContent = $apiInstance->uploadSignedResourcesChunk($id, $content_range, $session_id, $body, $content_disposition, $x_ads_region);
+    print_r($resultUploadContent);
+    //Upload file as stream
+    $resultUploadFile = $apiInstance->uploadSignedResourcesChunk($id, $content_range, $session_id, $fileHandle, $content_disposition, $x_ads_region);
+    print_r($resultUploadFile);
+    
 } catch (Exception $e) {
     echo 'Exception when calling ObjectsApi->uploadSignedResourcesChunk: ', $e->getMessage(), PHP_EOL;
 }
@@ -681,7 +698,7 @@ Name | Type | Description  | Notes
  **id** | **string**| Id of signed resource |
  **content_range** | **string**| Byte range of a segment being uploaded |
  **session_id** | **string**| Unique identifier of a session of a file being uploaded |
- **body** | **\SplFileObject**|  |
+ **body | fileHandle ** | **file contents or resource handle**|  |
  **content_disposition** | **string**| The suggested default filename when downloading this object to a file after it has been uploaded. | [optional]
  **x_ads_region** | **string**| The region where the bucket resides Acceptable values: &#x60;US&#x60;, &#x60;EMEA&#x60; Default is &#x60;US&#x60; | [optional] [default to US]
 

--- a/docs/Api/ObjectsApi.md
+++ b/docs/Api/ObjectsApi.md
@@ -698,7 +698,7 @@ Name | Type | Description  | Notes
  **id** | **string**| Id of signed resource |
  **content_range** | **string**| Byte range of a segment being uploaded |
  **session_id** | **string**| Unique identifier of a session of a file being uploaded |
- **body or fileHandle ** | **file contents or resource handle**|  |
+ **body or fileHandle** | **string or resource handle**|  |
  **content_disposition** | **string**| The suggested default filename when downloading this object to a file after it has been uploaded. | [optional]
  **x_ads_region** | **string**| The region where the bucket resides Acceptable values: &#x60;US&#x60;, &#x60;EMEA&#x60; Default is &#x60;US&#x60; | [optional] [default to US]
 

--- a/docs/Api/ObjectsApi.md
+++ b/docs/Api/ObjectsApi.md
@@ -5,19 +5,19 @@ All URIs are relative to *https://developer.api.autodesk.com*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
-[**copyTo**](ObjectsApi.md#copyTo) | **PUT** /oss/v2/buckets/{bucketKey}/objects/{objectName}/copyto/{newObjName} | 
-[**createSignedResource**](ObjectsApi.md#createSignedResource) | **POST** /oss/v2/buckets/{bucketKey}/objects/{objectName}/signed | 
-[**deleteObject**](ObjectsApi.md#deleteObject) | **DELETE** /oss/v2/buckets/{bucketKey}/objects/{objectName} | 
-[**deleteSignedResource**](ObjectsApi.md#deleteSignedResource) | **DELETE** /oss/v2/signedresources/{id} | 
-[**getObject**](ObjectsApi.md#getObject) | **GET** /oss/v2/buckets/{bucketKey}/objects/{objectName} | 
-[**getObjectDetails**](ObjectsApi.md#getObjectDetails) | **GET** /oss/v2/buckets/{bucketKey}/objects/{objectName}/details | 
-[**getObjects**](ObjectsApi.md#getObjects) | **GET** /oss/v2/buckets/{bucketKey}/objects | 
-[**getSignedResource**](ObjectsApi.md#getSignedResource) | **GET** /oss/v2/signedresources/{id} | 
-[**getStatusBySessionId**](ObjectsApi.md#getStatusBySessionId) | **GET** /oss/v2/buckets/{bucketKey}/objects/{objectName}/status/{sessionId} | 
-[**uploadChunk**](ObjectsApi.md#uploadChunk) | **PUT** /oss/v2/buckets/{bucketKey}/objects/{objectName}/resumable | 
-[**uploadObject**](ObjectsApi.md#uploadObject) | **PUT** /oss/v2/buckets/{bucketKey}/objects/{objectName} | 
-[**uploadSignedResource**](ObjectsApi.md#uploadSignedResource) | **PUT** /oss/v2/signedresources/{id} | 
-[**uploadSignedResourcesChunk**](ObjectsApi.md#uploadSignedResourcesChunk) | **PUT** /oss/v2/signedresources/{id}/resumable | 
+[**copyTo**](ObjectsApi.md#copyTo) | **PUT** /oss/v2/buckets/{bucketKey}/objects/{objectName}/copyto/{newObjName} |
+[**createSignedResource**](ObjectsApi.md#createSignedResource) | **POST** /oss/v2/buckets/{bucketKey}/objects/{objectName}/signed |
+[**deleteObject**](ObjectsApi.md#deleteObject) | **DELETE** /oss/v2/buckets/{bucketKey}/objects/{objectName} |
+[**deleteSignedResource**](ObjectsApi.md#deleteSignedResource) | **DELETE** /oss/v2/signedresources/{id} |
+[**getObject**](ObjectsApi.md#getObject) | **GET** /oss/v2/buckets/{bucketKey}/objects/{objectName} |
+[**getObjectDetails**](ObjectsApi.md#getObjectDetails) | **GET** /oss/v2/buckets/{bucketKey}/objects/{objectName}/details |
+[**getObjects**](ObjectsApi.md#getObjects) | **GET** /oss/v2/buckets/{bucketKey}/objects |
+[**getSignedResource**](ObjectsApi.md#getSignedResource) | **GET** /oss/v2/signedresources/{id} |
+[**getStatusBySessionId**](ObjectsApi.md#getStatusBySessionId) | **GET** /oss/v2/buckets/{bucketKey}/objects/{objectName}/status/{sessionId} |
+[**uploadChunk**](ObjectsApi.md#uploadChunk) | **PUT** /oss/v2/buckets/{bucketKey}/objects/{objectName}/resumable |
+[**uploadObject**](ObjectsApi.md#uploadObject) | **PUT** /oss/v2/buckets/{bucketKey}/objects/{objectName} |
+[**uploadSignedResource**](ObjectsApi.md#uploadSignedResource) | **PUT** /oss/v2/signedresources/{id} |
+[**uploadSignedResourcesChunk**](ObjectsApi.md#uploadSignedResourcesChunk) | **PUT** /oss/v2/signedresources/{id}/resumable |
 
 
 # **copyTo**
@@ -490,12 +490,13 @@ $object_name = "object_name_example"; // string | URL-encoded object name
 $content_length = 56; // int | Indicates the size of the request body.
 $content_range = "content_range_example"; // string | Byte range of a segment being uploaded
 $session_id = "session_id_example"; // string | Unique identifier of a session of a file being uploaded
-$body = "file contents"; // string | File contents 
+$body = "file contents or resource handle"; // either string | File contents or resource | File stream
 $content_disposition = "content_disposition_example"; // string | The suggested default filename when downloading this object to a file after it has been uploaded.
 $if_match = "if_match_example"; // string | If-Match header containing a SHA-1 hash of the bytes in the request body can be sent by the calling service or client application with the request. If present, OSS will use the value of If-Match header to verify that a SHA-1 calculated for the uploaded bytes server side matches what was sent in the header. If not, the request is failed with a status 412 Precondition Failed and the data is not written.
 
 try {
-    $result = $apiInstance->uploadChunk($bucket_key, $object_name, $content_length, $content_range, $session_id, $body, $content_disposition, $if_match);
+    $fileHandle = fopen('/path/to/file', 'r+');
+    $result = $apiInstance->uploadChunk($bucket_key, $object_name, $content_length, $content_range, $session_id, $fileHandle, $content_disposition, $if_match);
     print_r($result);
 } catch (Exception $e) {
     echo 'Exception when calling ObjectsApi->uploadChunk: ', $e->getMessage(), PHP_EOL;
@@ -512,7 +513,7 @@ Name | Type | Description  | Notes
  **content_length** | **int**| Indicates the size of the request body. |
  **content_range** | **string**| Byte range of a segment being uploaded |
  **session_id** | **string**| Unique identifier of a session of a file being uploaded |
- **body** | **\SplFileObject**|  |
+ **body** | **string or resource**| File contents or its resource handle |
  **content_disposition** | **string**| The suggested default filename when downloading this object to a file after it has been uploaded. | [optional]
  **if_match** | **string**| If-Match header containing a SHA-1 hash of the bytes in the request body can be sent by the calling service or client application with the request. If present, OSS will use the value of If-Match header to verify that a SHA-1 calculated for the uploaded bytes server side matches what was sent in the header. If not, the request is failed with a status 412 Precondition Failed and the data is not written. | [optional]
 
@@ -547,12 +548,13 @@ $apiInstance = new Autodesk\Forge\Client\Api\ObjectsApi($authObject);
 $bucket_key = "bucket_key_example"; // string | URL-encoded bucket key
 $object_name = "object_name_example"; // string | URL-encoded object name
 $content_length = 56; // int | Indicates the size of the request body.
-$body = "file contents"; // string | File contents 
+$body = "file contents or resource handle"; // either string or File contents or resource handle
 $content_disposition = "content_disposition_example"; // string | The suggested default filename when downloading this object to a file after it has been uploaded.
 $if_match = "if_match_example"; // string | If-Match header containing a SHA-1 hash of the bytes in the request body can be sent by the calling service or client application with the request. If present, OSS will use the value of If-Match header to verify that a SHA-1 calculated for the uploaded bytes server side matches what was sent in the header. If not, the request is failed with a status 412 Precondition Failed and the data is not written.
 
 try {
-    $result = $apiInstance->uploadObject($bucket_key, $object_name, $content_length, $body, $content_disposition, $if_match);
+    $fileHandle = fopen('/path/to/file', 'r+');
+    $result = $apiInstance->uploadObject($bucket_key, $object_name, $content_length, $fileHandle, $content_disposition, $if_match);
     print_r($result);
 } catch (Exception $e) {
     echo 'Exception when calling ObjectsApi->uploadObject: ', $e->getMessage(), PHP_EOL;
@@ -567,7 +569,7 @@ Name | Type | Description  | Notes
  **bucket_key** | **string**| URL-encoded bucket key |
  **object_name** | **string**| URL-encoded object name |
  **content_length** | **int**| Indicates the size of the request body. |
- **body** | **\SplFileObject**|  |
+ **body** | **string or resource**| File contents or its resource handle |
  **content_disposition** | **string**| The suggested default filename when downloading this object to a file after it has been uploaded. | [optional]
  **if_match** | **string**| If-Match header containing a SHA-1 hash of the bytes in the request body can be sent by the calling service or client application with the request. If present, OSS will use the value of If-Match header to verify that a SHA-1 calculated for the uploaded bytes server side matches what was sent in the header. If not, the request is failed with a status 412 Precondition Failed and the data is not written. | [optional]
 
@@ -601,13 +603,14 @@ require_once(__DIR__ . '/vendor/autoload.php');
 $apiInstance = new Autodesk\Forge\Client\Api\ObjectsApi($authObject);
 $id = "id_example"; // string | Id of signed resource
 $content_length = 56; // int | Indicates the size of the request body.
-$body = "file contents"; // string | File contents
+$body = "file contents or resource handle"; // either string or File contents or resource handle
 $content_disposition = "content_disposition_example"; // string | The suggested default filename when downloading this object to a file after it has been uploaded.
 $x_ads_region = "US"; // string | The region where the bucket resides Acceptable values: `US`, `EMEA` Default is `US`
 $if_match = "if_match_example"; // string | If-Match header containing a SHA-1 hash of the bytes in the request body can be sent by the calling service or client application with the request. If present, OSS will use the value of If-Match header to verify that a SHA-1 calculated for the uploaded bytes server side matches what was sent in the header. If not, the request is failed with a status 412 Precondition Failed and the data is not written.
 
 try {
-    $result = $apiInstance->uploadSignedResource($id, $content_length, $body, $content_disposition, $x_ads_region, $if_match);
+    $fileHandle = fopen('/path/to/file', 'r+');
+    $result = $apiInstance->uploadSignedResource($id, $content_length, $fileHandle, $content_disposition, $x_ads_region, $if_match);
     print_r($result);
 } catch (Exception $e) {
     echo 'Exception when calling ObjectsApi->uploadSignedResource: ', $e->getMessage(), PHP_EOL;
@@ -621,7 +624,7 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **id** | **string**| Id of signed resource |
  **content_length** | **int**| Indicates the size of the request body. |
- **body** | **\SplFileObject**|  |
+ **body** | **string or resource**| File contents or its resource handle |
  **content_disposition** | **string**| The suggested default filename when downloading this object to a file after it has been uploaded. | [optional]
  **x_ads_region** | **string**| The region where the bucket resides Acceptable values: &#x60;US&#x60;, &#x60;EMEA&#x60; Default is &#x60;US&#x60; | [optional] [default to US]
  **if_match** | **string**| If-Match header containing a SHA-1 hash of the bytes in the request body can be sent by the calling service or client application with the request. If present, OSS will use the value of If-Match header to verify that a SHA-1 calculated for the uploaded bytes server side matches what was sent in the header. If not, the request is failed with a status 412 Precondition Failed and the data is not written. | [optional]
@@ -657,12 +660,13 @@ $apiInstance = new Autodesk\Forge\Client\Api\ObjectsApi($authObject);
 $id = "id_example"; // string | Id of signed resource
 $content_range = "content_range_example"; // string | Byte range of a segment being uploaded
 $session_id = "session_id_example"; // string | Unique identifier of a session of a file being uploaded
-$body = "file contents"; // string | File contents
+$body = "file contents or resource handle"; // either string or File contents or resource handle
 $content_disposition = "content_disposition_example"; // string | The suggested default filename when downloading this object to a file after it has been uploaded.
 $x_ads_region = "US"; // string | The region where the bucket resides Acceptable values: `US`, `EMEA` Default is `US`
 
 try {
-    $result = $apiInstance->uploadSignedResourcesChunk($id, $content_range, $session_id, $body, $content_disposition, $x_ads_region);
+    $fileHandle = fopen('/path/to/file', 'r+');
+    $result = $apiInstance->uploadSignedResourcesChunk($id, $content_range, $session_id, $fileHandle, $content_disposition, $x_ads_region);
     print_r($result);
 } catch (Exception $e) {
     echo 'Exception when calling ObjectsApi->uploadSignedResourcesChunk: ', $e->getMessage(), PHP_EOL;

--- a/docs/Api/ObjectsApi.md
+++ b/docs/Api/ObjectsApi.md
@@ -1,3 +1,4 @@
+
 # Autodesk\Forge\Client\ObjectsApi
 
 All URIs are relative to *https://developer.api.autodesk.com*
@@ -489,7 +490,7 @@ $object_name = "object_name_example"; // string | URL-encoded object name
 $content_length = 56; // int | Indicates the size of the request body.
 $content_range = "content_range_example"; // string | Byte range of a segment being uploaded
 $session_id = "session_id_example"; // string | Unique identifier of a session of a file being uploaded
-$body = "/path/to/file.txt"; // \SplFileObject | 
+$body = "file contents"; // string | File contents 
 $content_disposition = "content_disposition_example"; // string | The suggested default filename when downloading this object to a file after it has been uploaded.
 $if_match = "if_match_example"; // string | If-Match header containing a SHA-1 hash of the bytes in the request body can be sent by the calling service or client application with the request. If present, OSS will use the value of If-Match header to verify that a SHA-1 calculated for the uploaded bytes server side matches what was sent in the header. If not, the request is failed with a status 412 Precondition Failed and the data is not written.
 
@@ -546,7 +547,7 @@ $apiInstance = new Autodesk\Forge\Client\Api\ObjectsApi($authObject);
 $bucket_key = "bucket_key_example"; // string | URL-encoded bucket key
 $object_name = "object_name_example"; // string | URL-encoded object name
 $content_length = 56; // int | Indicates the size of the request body.
-$body = "/path/to/file.txt"; // \SplFileObject | 
+$body = "file contents"; // string | File contents 
 $content_disposition = "content_disposition_example"; // string | The suggested default filename when downloading this object to a file after it has been uploaded.
 $if_match = "if_match_example"; // string | If-Match header containing a SHA-1 hash of the bytes in the request body can be sent by the calling service or client application with the request. If present, OSS will use the value of If-Match header to verify that a SHA-1 calculated for the uploaded bytes server side matches what was sent in the header. If not, the request is failed with a status 412 Precondition Failed and the data is not written.
 
@@ -600,7 +601,7 @@ require_once(__DIR__ . '/vendor/autoload.php');
 $apiInstance = new Autodesk\Forge\Client\Api\ObjectsApi($authObject);
 $id = "id_example"; // string | Id of signed resource
 $content_length = 56; // int | Indicates the size of the request body.
-$body = "/path/to/file.txt"; // \SplFileObject | 
+$body = "file contents"; // string | File contents
 $content_disposition = "content_disposition_example"; // string | The suggested default filename when downloading this object to a file after it has been uploaded.
 $x_ads_region = "US"; // string | The region where the bucket resides Acceptable values: `US`, `EMEA` Default is `US`
 $if_match = "if_match_example"; // string | If-Match header containing a SHA-1 hash of the bytes in the request body can be sent by the calling service or client application with the request. If present, OSS will use the value of If-Match header to verify that a SHA-1 calculated for the uploaded bytes server side matches what was sent in the header. If not, the request is failed with a status 412 Precondition Failed and the data is not written.
@@ -656,7 +657,7 @@ $apiInstance = new Autodesk\Forge\Client\Api\ObjectsApi($authObject);
 $id = "id_example"; // string | Id of signed resource
 $content_range = "content_range_example"; // string | Byte range of a segment being uploaded
 $session_id = "session_id_example"; // string | Unique identifier of a session of a file being uploaded
-$body = "/path/to/file.txt"; // \SplFileObject | 
+$body = "file contents"; // string | File contents
 $content_disposition = "content_disposition_example"; // string | The suggested default filename when downloading this object to a file after it has been uploaded.
 $x_ads_region = "US"; // string | The region where the bucket resides Acceptable values: `US`, `EMEA` Default is `US`
 

--- a/docs/Api/ObjectsApi.md
+++ b/docs/Api/ObjectsApi.md
@@ -497,10 +497,10 @@ $if_match = "if_match_example"; // string | If-Match header containing a SHA-1 h
 
 try {
     //Upload file contents
-    $resultUploadContent = $apiInstance->uploadSignedResourcesChunk($id, $content_range, $session_id, $body, $content_disposition, $x_ads_region);
+    $resultUploadContent = $apiInstance->uploadChunk($bucket_key, $object_name, $content_length, $content_range, $session_id, $body, $content_disposition, $if_match);
     print_r($resultUploadContent);
     //Upload file as stream
-    $resultUploadFile = $apiInstance->uploadSignedResourcesChunk($id, $content_range, $session_id, $fileHandle, $content_disposition, $x_ads_region);
+    $resultUploadFile = $apiInstance->uploadChunk($bucket_key, $object_name, $content_length, $content_range, $session_id, $fileHandle, $content_disposition, $if_match);
     print_r($resultUploadFile);
 } catch (Exception $e) {
     echo 'Exception when calling ObjectsApi->uploadChunk: ', $e->getMessage(), PHP_EOL;
@@ -517,7 +517,7 @@ Name | Type | Description  | Notes
  **content_length** | **int**| Indicates the size of the request body. |
  **content_range** | **string**| Byte range of a segment being uploaded |
  **session_id** | **string**| Unique identifier of a session of a file being uploaded |
- **body | fileHandle** | **string or resource**| File contents or its resource handle |
+ **body or fileHandle** | **string or resource**| File contents or its resource handle |
  **content_disposition** | **string**| The suggested default filename when downloading this object to a file after it has been uploaded. | [optional]
  **if_match** | **string**| If-Match header containing a SHA-1 hash of the bytes in the request body can be sent by the calling service or client application with the request. If present, OSS will use the value of If-Match header to verify that a SHA-1 calculated for the uploaded bytes server side matches what was sent in the header. If not, the request is failed with a status 412 Precondition Failed and the data is not written. | [optional]
 
@@ -559,10 +559,10 @@ $if_match = "if_match_example"; // string | If-Match header containing a SHA-1 h
 
 try {
      //Upload file contents
-    $resultUploadContent = $apiInstance->uploadSignedResourcesChunk($id, $content_range, $session_id, $body, $content_disposition, $x_ads_region);
+    $resultUploadContent = $apiInstance->uploadObject($bucket_key, $object_name, $content_length, $body, $content_disposition, $if_match);
     print_r($resultUploadContent);
     //Upload file as stream
-    $resultUploadFile = $apiInstance->uploadSignedResourcesChunk($id, $content_range, $session_id, $fileHandle, $content_disposition, $x_ads_region);
+    $resultUploadFile = $apiInstance->uploadObject($bucket_key, $object_name, $content_length, $fileHandle, $content_disposition, $if_match);
     print_r($resultUploadFile);
 } catch (Exception $e) {
     echo 'Exception when calling ObjectsApi->uploadObject: ', $e->getMessage(), PHP_EOL;
@@ -577,7 +577,7 @@ Name | Type | Description  | Notes
  **bucket_key** | **string**| URL-encoded bucket key |
  **object_name** | **string**| URL-encoded object name |
  **content_length** | **int**| Indicates the size of the request body. |
- **body | fileHandle** | **string or resource**| File contents or its resource handle |
+ **body or fileHandle** | **string or resource**| File contents or its resource handle |
  **content_disposition** | **string**| The suggested default filename when downloading this object to a file after it has been uploaded. | [optional]
  **if_match** | **string**| If-Match header containing a SHA-1 hash of the bytes in the request body can be sent by the calling service or client application with the request. If present, OSS will use the value of If-Match header to verify that a SHA-1 calculated for the uploaded bytes server side matches what was sent in the header. If not, the request is failed with a status 412 Precondition Failed and the data is not written. | [optional]
 
@@ -619,10 +619,10 @@ $if_match = "if_match_example"; // string | If-Match header containing a SHA-1 h
 
 try {
     //Upload file contents
-    $resultUploadContent = $apiInstance->uploadSignedResourcesChunk($id, $content_range, $session_id, $body, $content_disposition, $x_ads_region);
+    $resultUploadContent = $apiInstance->uploadSignedResource($id, $content_length, $body, $content_disposition, $x_ads_region, $if_match);
     print_r($resultUploadContent);
     //Upload file as stream
-    $resultUploadFile = $apiInstance->uploadSignedResourcesChunk($id, $content_range, $session_id, $fileHandle, $content_disposition, $x_ads_region);
+    $resultUploadFile = $apiInstance->uploadSignedResource($id, $content_length, $fileHandle, $content_disposition, $x_ads_region, $if_match);
     print_r($resultUploadFile);
 } catch (Exception $e) {
     echo 'Exception when calling ObjectsApi->uploadSignedResource: ', $e->getMessage(), PHP_EOL;
@@ -636,7 +636,7 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **id** | **string**| Id of signed resource |
  **content_length** | **int**| Indicates the size of the request body. |
- **body | fileHandle** | **string or resource**| File contents or its resource handle |
+ **body or fileHandle** | **string or resource**| File contents or its resource handle |
  **content_disposition** | **string**| The suggested default filename when downloading this object to a file after it has been uploaded. | [optional]
  **x_ads_region** | **string**| The region where the bucket resides Acceptable values: &#x60;US&#x60;, &#x60;EMEA&#x60; Default is &#x60;US&#x60; | [optional] [default to US]
  **if_match** | **string**| If-Match header containing a SHA-1 hash of the bytes in the request body can be sent by the calling service or client application with the request. If present, OSS will use the value of If-Match header to verify that a SHA-1 calculated for the uploaded bytes server side matches what was sent in the header. If not, the request is failed with a status 412 Precondition Failed and the data is not written. | [optional]
@@ -698,7 +698,7 @@ Name | Type | Description  | Notes
  **id** | **string**| Id of signed resource |
  **content_range** | **string**| Byte range of a segment being uploaded |
  **session_id** | **string**| Unique identifier of a session of a file being uploaded |
- **body | fileHandle ** | **file contents or resource handle**|  |
+ **body or fileHandle ** | **file contents or resource handle**|  |
  **content_disposition** | **string**| The suggested default filename when downloading this object to a file after it has been uploaded. | [optional]
  **x_ads_region** | **string**| The region where the bucket resides Acceptable values: &#x60;US&#x60;, &#x60;EMEA&#x60; Default is &#x60;US&#x60; | [optional] [default to US]
 

--- a/lib/Api/ObjectsApi.php
+++ b/lib/Api/ObjectsApi.php
@@ -1094,7 +1094,7 @@ class ObjectsApi extends AbstractApi
      * @param int $content_length Indicates the size of the request body. (required)
      * @param string $content_range Byte range of a segment being uploaded (required)
      * @param string $session_id Unique identifier of a session of a file being uploaded (required)
-     * @param \SplFileObject $body (required)
+     * @param string $body File content (required)
      * @param string $content_disposition The suggested default filename when downloading this object to a file after it has been uploaded. (optional)
      * @param string $if_match If-Match header containing a SHA-1 hash of the bytes in the request body can be sent by the calling service or client application with the request. If present, OSS will use the value of If-Match header to verify that a SHA-1 calculated for the uploaded bytes server side matches what was sent in the header. If not, the request is failed with a status 412 Precondition Failed and the data is not written. (optional)
      * @throws \Autodesk\Forge\Client\ApiException on non-2xx response
@@ -1411,7 +1411,7 @@ class ObjectsApi extends AbstractApi
      *
      * @param string $id Id of signed resource (required)
      * @param int $content_length Indicates the size of the request body. (required)
-     * @param \SplFileObject $body (required)
+     * @param string $body File content (required)
      * @param string $content_disposition The suggested default filename when downloading this object to a file after it has been uploaded. (optional)
      * @param string $x_ads_region The region where the bucket resides Acceptable values: &#x60;US&#x60;, &#x60;EMEA&#x60; Default is &#x60;US&#x60; (optional, default to US)
      * @param string $if_match If-Match header containing a SHA-1 hash of the bytes in the request body can be sent by the calling service or client application with the request. If present, OSS will use the value of If-Match header to verify that a SHA-1 calculated for the uploaded bytes server side matches what was sent in the header. If not, the request is failed with a status 412 Precondition Failed and the data is not written. (optional)
@@ -1431,7 +1431,7 @@ class ObjectsApi extends AbstractApi
      *
      * @param string $id Id of signed resource (required)
      * @param int $content_length Indicates the size of the request body. (required)
-     * @param \SplFileObject $body (required)
+     * @param string $body File content (required)
      * @param string $content_disposition The suggested default filename when downloading this object to a file after it has been uploaded. (optional)
      * @param string $x_ads_region The region where the bucket resides Acceptable values: &#x60;US&#x60;, &#x60;EMEA&#x60; Default is &#x60;US&#x60; (optional, default to US)
      * @param string $if_match If-Match header containing a SHA-1 hash of the bytes in the request body can be sent by the calling service or client application with the request. If present, OSS will use the value of If-Match header to verify that a SHA-1 calculated for the uploaded bytes server side matches what was sent in the header. If not, the request is failed with a status 412 Precondition Failed and the data is not written. (optional)
@@ -1544,7 +1544,7 @@ class ObjectsApi extends AbstractApi
      * @param string $id Id of signed resource (required)
      * @param string $content_range Byte range of a segment being uploaded (required)
      * @param string $session_id Unique identifier of a session of a file being uploaded (required)
-     * @param \SplFileObject $body (required)
+     * @param string $body File content (required)
      * @param string $content_disposition The suggested default filename when downloading this object to a file after it has been uploaded. (optional)
      * @param string $x_ads_region The region where the bucket resides Acceptable values: &#x60;US&#x60;, &#x60;EMEA&#x60; Default is &#x60;US&#x60; (optional, default to US)
      * @throws \Autodesk\Forge\Client\ApiException on non-2xx response
@@ -1564,7 +1564,7 @@ class ObjectsApi extends AbstractApi
      * @param string $id Id of signed resource (required)
      * @param string $content_range Byte range of a segment being uploaded (required)
      * @param string $session_id Unique identifier of a session of a file being uploaded (required)
-     * @param \SplFileObject $body (required)
+     * @param string $body File content (required)
      * @param string $content_disposition The suggested default filename when downloading this object to a file after it has been uploaded. (optional)
      * @param string $x_ads_region The region where the bucket resides Acceptable values: &#x60;US&#x60;, &#x60;EMEA&#x60; Default is &#x60;US&#x60; (optional, default to US)
      * @throws \Autodesk\Forge\Client\ApiException on non-2xx response

--- a/lib/Api/ObjectsApi.php
+++ b/lib/Api/ObjectsApi.php
@@ -43,7 +43,7 @@ class ObjectsApi extends AbstractApi
     /**
      * Operation copyTo
      *
-     * 
+     *
      *
      * @param string $bucket_key URL-encoded bucket key (required)
      * @param string $object_name URL-encoded object name (required)
@@ -60,7 +60,7 @@ class ObjectsApi extends AbstractApi
     /**
      * Operation copyToWithHttpInfo
      *
-     * 
+     *
      *
      * @param string $bucket_key URL-encoded bucket key (required)
      * @param string $object_name URL-encoded object name (required)
@@ -125,7 +125,7 @@ class ObjectsApi extends AbstractApi
         // default format to json
         $resourcePath = str_replace("{format}", "json", $resourcePath);
 
-        
+
         // for model (json/xml)
         if (isset($_tempBody)) {
             $httpBody = $_tempBody; // $_tempBody is the method argument, if present
@@ -164,7 +164,7 @@ class ObjectsApi extends AbstractApi
     /**
      * Operation createSignedResource
      *
-     * 
+     *
      *
      * @param string $bucket_key URL-encoded bucket key (required)
      * @param string $object_name URL-encoded object name (required)
@@ -182,7 +182,7 @@ class ObjectsApi extends AbstractApi
     /**
      * Operation createSignedResourceWithHttpInfo
      *
-     * 
+     *
      *
      * @param string $bucket_key URL-encoded bucket key (required)
      * @param string $object_name URL-encoded object name (required)
@@ -288,7 +288,7 @@ class ObjectsApi extends AbstractApi
     /**
      * Operation deleteObject
      *
-     * 
+     *
      *
      * @param string $bucket_key URL-encoded bucket key (required)
      * @param string $object_name URL-encoded object name (required)
@@ -304,7 +304,7 @@ class ObjectsApi extends AbstractApi
     /**
      * Operation deleteObjectWithHttpInfo
      *
-     * 
+     *
      *
      * @param string $bucket_key URL-encoded bucket key (required)
      * @param string $object_name URL-encoded object name (required)
@@ -356,7 +356,7 @@ class ObjectsApi extends AbstractApi
         // default format to json
         $resourcePath = str_replace("{format}", "json", $resourcePath);
 
-        
+
         // for model (json/xml)
         if (isset($_tempBody)) {
             $httpBody = $_tempBody; // $_tempBody is the method argument, if present
@@ -387,7 +387,7 @@ class ObjectsApi extends AbstractApi
     /**
      * Operation deleteSignedResource
      *
-     * 
+     *
      *
      * @param string $id Id of signed resource (required)
      * @param string $region The region where the bucket resides Acceptable values: &#x60;US&#x60;, &#x60;EMEA&#x60; Default is &#x60;US&#x60; (optional, default to US)
@@ -403,7 +403,7 @@ class ObjectsApi extends AbstractApi
     /**
      * Operation deleteSignedResourceWithHttpInfo
      *
-     * 
+     *
      *
      * @param string $id Id of signed resource (required)
      * @param string $region The region where the bucket resides Acceptable values: &#x60;US&#x60;, &#x60;EMEA&#x60; Default is &#x60;US&#x60; (optional, default to US)
@@ -443,7 +443,7 @@ class ObjectsApi extends AbstractApi
         // default format to json
         $resourcePath = str_replace("{format}", "json", $resourcePath);
 
-        
+
         // for model (json/xml)
         if (isset($_tempBody)) {
             $httpBody = $_tempBody; // $_tempBody is the method argument, if present
@@ -474,7 +474,7 @@ class ObjectsApi extends AbstractApi
     /**
      * Operation getObject
      *
-     * 
+     *
      *
      * @param string $bucket_key URL-encoded bucket key (required)
      * @param string $object_name URL-encoded object name (required)
@@ -494,7 +494,7 @@ class ObjectsApi extends AbstractApi
     /**
      * Operation getObjectWithHttpInfo
      *
-     * 
+     *
      *
      * @param string $bucket_key URL-encoded bucket key (required)
      * @param string $object_name URL-encoded object name (required)
@@ -570,7 +570,7 @@ class ObjectsApi extends AbstractApi
         // default format to json
         $resourcePath = str_replace("{format}", "json", $resourcePath);
 
-        
+
         // for model (json/xml)
         if (isset($_tempBody)) {
             $httpBody = $_tempBody; // $_tempBody is the method argument, if present
@@ -609,7 +609,7 @@ class ObjectsApi extends AbstractApi
     /**
      * Operation getObjectDetails
      *
-     * 
+     *
      *
      * @param string $bucket_key URL-encoded bucket key (required)
      * @param string $object_name URL-encoded object name (required)
@@ -627,7 +627,7 @@ class ObjectsApi extends AbstractApi
     /**
      * Operation getObjectDetailsWithHttpInfo
      *
-     * 
+     *
      *
      * @param string $bucket_key URL-encoded bucket key (required)
      * @param string $object_name URL-encoded object name (required)
@@ -689,7 +689,7 @@ class ObjectsApi extends AbstractApi
         // default format to json
         $resourcePath = str_replace("{format}", "json", $resourcePath);
 
-        
+
         // for model (json/xml)
         if (isset($_tempBody)) {
             $httpBody = $_tempBody; // $_tempBody is the method argument, if present
@@ -728,7 +728,7 @@ class ObjectsApi extends AbstractApi
     /**
      * Operation getObjects
      *
-     * 
+     *
      *
      * @param string $bucket_key URL-encoded bucket key (required)
      * @param int $limit Limit to the response size, Acceptable values: 1-100 Default &#x3D; 10 (optional, default to 10)
@@ -746,7 +746,7 @@ class ObjectsApi extends AbstractApi
     /**
      * Operation getObjectsWithHttpInfo
      *
-     * 
+     *
      *
      * @param string $bucket_key URL-encoded bucket key (required)
      * @param int $limit Limit to the response size, Acceptable values: 1-100 Default &#x3D; 10 (optional, default to 10)
@@ -800,7 +800,7 @@ class ObjectsApi extends AbstractApi
         // default format to json
         $resourcePath = str_replace("{format}", "json", $resourcePath);
 
-        
+
         // for model (json/xml)
         if (isset($_tempBody)) {
             $httpBody = $_tempBody; // $_tempBody is the method argument, if present
@@ -839,7 +839,7 @@ class ObjectsApi extends AbstractApi
     /**
      * Operation getSignedResource
      *
-     * 
+     *
      *
      * @param string $id Id of signed resource (required)
      * @param string $range A range of bytes to download from the specified object. (optional)
@@ -859,7 +859,7 @@ class ObjectsApi extends AbstractApi
     /**
      * Operation getSignedResourceWithHttpInfo
      *
-     * 
+     *
      *
      * @param string $id Id of signed resource (required)
      * @param string $range A range of bytes to download from the specified object. (optional)
@@ -923,7 +923,7 @@ class ObjectsApi extends AbstractApi
         // default format to json
         $resourcePath = str_replace("{format}", "json", $resourcePath);
 
-        
+
         // for model (json/xml)
         if (isset($_tempBody)) {
             $httpBody = $_tempBody; // $_tempBody is the method argument, if present
@@ -966,7 +966,7 @@ class ObjectsApi extends AbstractApi
     /**
      * Operation getStatusBySessionId
      *
-     * 
+     *
      *
      * @param string $bucket_key URL-encoded bucket key (required)
      * @param string $object_name URL-encoded object name (required)
@@ -983,7 +983,7 @@ class ObjectsApi extends AbstractApi
     /**
      * Operation getStatusBySessionIdWithHttpInfo
      *
-     * 
+     *
      *
      * @param string $bucket_key URL-encoded bucket key (required)
      * @param string $object_name URL-encoded object name (required)
@@ -1048,7 +1048,7 @@ class ObjectsApi extends AbstractApi
         // default format to json
         $resourcePath = str_replace("{format}", "json", $resourcePath);
 
-        
+
         // for model (json/xml)
         if (isset($_tempBody)) {
             $httpBody = $_tempBody; // $_tempBody is the method argument, if present
@@ -1087,7 +1087,7 @@ class ObjectsApi extends AbstractApi
     /**
      * Operation uploadChunk
      *
-     * 
+     *
      *
      * @param string $bucket_key URL-encoded bucket key (required)
      * @param string $object_name URL-encoded object name (required)
@@ -1109,7 +1109,7 @@ class ObjectsApi extends AbstractApi
     /**
      * Operation uploadChunkWithHttpInfo
      *
-     * 
+     *
      *
      * @param string $bucket_key URL-encoded bucket key (required)
      * @param string $object_name URL-encoded object name (required)
@@ -1263,7 +1263,7 @@ class ObjectsApi extends AbstractApi
     /**
      * Operation uploadObject
      *
-     * 
+     *
      *
      * @param string $bucket_key URL-encoded bucket key (required)
      * @param string $object_name URL-encoded object name (required)
@@ -1283,7 +1283,7 @@ class ObjectsApi extends AbstractApi
     /**
      * Operation uploadObjectWithHttpInfo
      *
-     * 
+     *
      *
      * @param string $bucket_key URL-encoded bucket key (required)
      * @param string $object_name URL-encoded object name (required)
@@ -1407,11 +1407,11 @@ class ObjectsApi extends AbstractApi
     /**
      * Operation uploadSignedResource
      *
-     * 
+     *
      *
      * @param string $id Id of signed resource (required)
      * @param int $content_length Indicates the size of the request body. (required)
-     * @param string $body File content (required)
+     * @param string $body File content (required) or file resource handle
      * @param string $content_disposition The suggested default filename when downloading this object to a file after it has been uploaded. (optional)
      * @param string $x_ads_region The region where the bucket resides Acceptable values: &#x60;US&#x60;, &#x60;EMEA&#x60; Default is &#x60;US&#x60; (optional, default to US)
      * @param string $if_match If-Match header containing a SHA-1 hash of the bytes in the request body can be sent by the calling service or client application with the request. If present, OSS will use the value of If-Match header to verify that a SHA-1 calculated for the uploaded bytes server side matches what was sent in the header. If not, the request is failed with a status 412 Precondition Failed and the data is not written. (optional)
@@ -1427,11 +1427,11 @@ class ObjectsApi extends AbstractApi
     /**
      * Operation uploadSignedResourceWithHttpInfo
      *
-     * 
+     *
      *
      * @param string $id Id of signed resource (required)
      * @param int $content_length Indicates the size of the request body. (required)
-     * @param string $body File content (required)
+     * @param string $body File content (required) or file resource handle
      * @param string $content_disposition The suggested default filename when downloading this object to a file after it has been uploaded. (optional)
      * @param string $x_ads_region The region where the bucket resides Acceptable values: &#x60;US&#x60;, &#x60;EMEA&#x60; Default is &#x60;US&#x60; (optional, default to US)
      * @param string $if_match If-Match header containing a SHA-1 hash of the bytes in the request body can be sent by the calling service or client application with the request. If present, OSS will use the value of If-Match header to verify that a SHA-1 calculated for the uploaded bytes server side matches what was sent in the header. If not, the request is failed with a status 412 Precondition Failed and the data is not written. (optional)
@@ -1539,12 +1539,12 @@ class ObjectsApi extends AbstractApi
     /**
      * Operation uploadSignedResourcesChunk
      *
-     * 
+     *
      *
      * @param string $id Id of signed resource (required)
      * @param string $content_range Byte range of a segment being uploaded (required)
      * @param string $session_id Unique identifier of a session of a file being uploaded (required)
-     * @param string $body File content (required)
+     * @param string $body File content (required) or file resource handle
      * @param string $content_disposition The suggested default filename when downloading this object to a file after it has been uploaded. (optional)
      * @param string $x_ads_region The region where the bucket resides Acceptable values: &#x60;US&#x60;, &#x60;EMEA&#x60; Default is &#x60;US&#x60; (optional, default to US)
      * @throws \Autodesk\Forge\Client\ApiException on non-2xx response
@@ -1559,12 +1559,12 @@ class ObjectsApi extends AbstractApi
     /**
      * Operation uploadSignedResourcesChunkWithHttpInfo
      *
-     * 
+     *
      *
      * @param string $id Id of signed resource (required)
      * @param string $content_range Byte range of a segment being uploaded (required)
      * @param string $session_id Unique identifier of a session of a file being uploaded (required)
-     * @param string $body File content (required)
+     * @param string $body File content (required) or file resource handle
      * @param string $content_disposition The suggested default filename when downloading this object to a file after it has been uploaded. (optional)
      * @param string $x_ads_region The region where the bucket resides Acceptable values: &#x60;US&#x60;, &#x60;EMEA&#x60; Default is &#x60;US&#x60; (optional, default to US)
      * @throws \Autodesk\Forge\Client\ApiException on non-2xx response

--- a/lib/ApiClient.php
+++ b/lib/ApiClient.php
@@ -148,7 +148,7 @@ class ApiClient
         if ($this->config->getCurlConnectTimeout() != 0) {
             curl_setopt($curl, CURLOPT_CONNECTTIMEOUT, $this->config->getCurlConnectTimeout());
         }
-        
+
         // return the result on success, rather than just true
         curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
 
@@ -182,6 +182,11 @@ class ApiClient
 
         if ($method === self::$POST) {
             curl_setopt($curl, CURLOPT_POST, true);
+            if(is_resource($postData)) {
+              curl_setopt($curl, CURLOPT_INFILE, $postData);
+              curl_setopt($curl, CURLOPT_INFILESIZE, $headerParams['Content-Length']);
+              curl_setopt($curl, CURLOPT_UPLOAD, 1);
+            } else
             curl_setopt($curl, CURLOPT_POSTFIELDS, $postData);
         } elseif ($method === self::$HEAD) {
             curl_setopt($curl, CURLOPT_NOBODY, true);
@@ -190,9 +195,19 @@ class ApiClient
             curl_setopt($curl, CURLOPT_POSTFIELDS, $postData);
         } elseif ($method === self::$PATCH) {
             curl_setopt($curl, CURLOPT_CUSTOMREQUEST, "PATCH");
+            if(is_resource($postData)) {
+              curl_setopt($curl, CURLOPT_INFILE, $postData);
+              curl_setopt($curl, CURLOPT_INFILESIZE, $headerParams['Content-Length']);
+              curl_setopt($curl, CURLOPT_UPLOAD, 1);
+            } else
             curl_setopt($curl, CURLOPT_POSTFIELDS, $postData);
         } elseif ($method === self::$PUT) {
             curl_setopt($curl, CURLOPT_CUSTOMREQUEST, "PUT");
+            if(is_resource($postData)) {
+              curl_setopt($curl, CURLOPT_INFILE, $postData);
+              curl_setopt($curl, CURLOPT_INFILESIZE, $headerParams['Content-Length']);
+              curl_setopt($curl, CURLOPT_UPLOAD, 1);
+            } else
             curl_setopt($curl, CURLOPT_POSTFIELDS, $postData);
         } elseif ($method === self::$DELETE) {
             curl_setopt($curl, CURLOPT_CUSTOMREQUEST, "DELETE");


### PR DESCRIPTION
This is to address [issue#31](https://github.com/Autodesk-Forge/forge-php-client/issues/31) and some long standing issues with uploading large files.

Comments:

- Currently it's grabbing all the contents of a file to pass in as String chunk for upload which runs the risk of memory exhaustion and is largely inefficient
- Hence we will need to use either the CURLfile interface or simply pass in the file path with corrrespoing curlopts to let the underlying cURL deal with the data access directly. I will take care of this when time persists soon.

Change Log:

- Add support for `ApiClient.callApi` to accept file resource handle as `body` to improve efficiency/ease of usage and mitigate risk of running our of memory when loading large files
- Update docs to reflect the above